### PR TITLE
[tutorial] removing blank lines and leading whitespace in code excerpts (Chap. 2 to 4)

### DIFF
--- a/app/tutorial/04-ch02-controller.html
+++ b/app/tutorial/04-ch02-controller.html
@@ -173,10 +173,10 @@ to open the <strong>Chapter_02</strong> directory. </p>
   <p>The <code>publishAs</code> field specifies that the controller instance should be assigned to the current scope under the name specified. The controller’s public fields are available for data binding from the view through the <code>publishAs</code> name. Similarly, the controller’s public methods can be invoked from the view using the <code>publishAs</code> name. Here is an example:</p>
 
   <pre class="prettyprint">
-  &lt;div>&lt;strong&gt;Name: &lt;/strong&gt;{{ctrl.selectedRecipe.name}}&lt;/div&gt;
+&lt;div>&lt;strong&gt;Name: &lt;/strong&gt;{{ctrl.selectedRecipe.name}}&lt;/div&gt;
 
-  &lt;li ng-click="ctrl.selectRecipe(recipe)"&gt;{{recipe.name}}&lt;/li&gt;
-      </pre>
+&lt;li ng-click="ctrl.selectRecipe(recipe)"&gt;{{recipe.name}}&lt;/li&gt;
+</pre>
 
     <p>Here we also see how to tell the Angular bootstrapping code about our custom types. Angular uses dependency injection to instantiate the application classes you create. Inside the <a href="http://ci.angularjs.org/view/Dart/job/angular.dart-master/javadoc/angular.html#ngBootstrap"><code>ngBootstrap</code></a> method, a new <a href="http://ci.angularjs.org/view/Dart/job/angular.dart-master/javadoc/angular/AngularModule.html"><code>AngularModule</code></a> is created. The <code>AngularModule</code> provides all of Angular’s built in services and directives. Your app’s module is added to the list of modules that Angular loads.</p>
 
@@ -196,10 +196,9 @@ main() {
     <p>From the view, we can use the controller by adding a set of attributes to the element which will trigger the CSS selector declared on the controller:</p>
 
    <pre class="prettyprint">
-  &lt;div recipe-book&gt;
-      …
-  &lt;/div&gt;
-
+&lt;div recipe-book&gt;
+    …
+&lt;/div&gt;
 </pre>
   <p>Anything within the containing element has access to the controller’s scope.</p>
 
@@ -210,11 +209,11 @@ main() {
   <p>Now that you have a better understanding of scopes, let’s elaborate on them further by describing what’s going on behind the scenes with the <code>ng-repeat</code> tag.</p>
 
   <pre class="prettyprint">
-    &lt;ul&gt;
-      &lt;li class="pointer"
-          ng-repeat="recipe in ctrl.recipes"
-          ng-click="ctrl.selectRecipe(recipe)"&gt;{{recipe.name}}&lt;/li&gt;
-    &lt;/ul&gt;
+&lt;ul&gt;
+  &lt;li class="pointer"
+      ng-repeat="recipe in ctrl.recipes"
+      ng-click="ctrl.selectRecipe(recipe)"&gt;{{recipe.name}}&lt;/li&gt;
+&lt;/ul&gt;
 </pre>
 
   <p>The <code>ng-repeat</code> directive on the li element causes Angular to iterate over the model (the recipes property in the RecipeBookController), and clone the li in the compiled DOM for each recipe in the list. Each li is created with its own scope and its own instance of the recipe property. If the model changes (for example, if a recipe is added to or deleted from the model), the <code>ng-repeat</code> tag re-evaluates the model and updates the view automatically.</p>

--- a/app/tutorial/05-ch03-component.html
+++ b/app/tutorial/05-ch03-component.html
@@ -207,7 +207,7 @@ and how they’re used in the HTML template.</p>
 &lt;div recipe-book&gt;
     ...
 &lt;/div&gt;
-      </pre>
+</pre>
 
   <h5 id="templateurl-and-cssurl"><code>templateUrl</code> and <code>cssUrl</code></h5>
   <p>Since components are self contained,
@@ -225,11 +225,11 @@ Your app has no direct visibility into the internals of the component.</p>
 
   <p>Let’s look at our component’s HTML template:
 <pre class="prettyprint">
-   &lt;span class="stars"
-         ng-if="cmp.rating != null"
-         ng-repeat="star in cmp.stars"
-         ng-click="cmp.handleClick(star)"
-         ng-class="cmp.starClass(star)"&gt;
+&lt;span class="stars"
+      ng-if="cmp.rating != null"
+      ng-repeat="star in cmp.stars"
+      ng-click="cmp.handleClick(star)"
+      ng-class="cmp.starClass(star)"&gt;
   {{cmp.starChar(star)}}
 &lt;/span&gt;
 </pre>

--- a/app/tutorial/06-ch04-directive.html
+++ b/app/tutorial/06-ch04-directive.html
@@ -200,8 +200,7 @@ an Element representing the <code>&lt;span&gt;</code>.</p>
   <p>In general, when you want to implement a directive as an attribute that
 takes a value, do it like this:</p>
 
-  <pre class="prettyprint">
-@NgDirective(
+  <pre class="prettyprint">@NgDirective(
     selector: '[attributeName]'
 )
 class MyDirective {
@@ -212,8 +211,7 @@ class MyDirective {
     ...
   }
   ...
-}
-  </pre>
+}</pre>
 
   <p>AngularDart’s dependency injection system calls the constructor,
 supplying context-specific objects for
@@ -232,9 +230,9 @@ whenever the user mouses over an element that has a tooltip:</p>
 tooltipElem = new dom.DivElement();
 // ...Create children using info from displayModel…
 // ...Add the children to the &lt;div&gt;...
-          // ...Style the &lt;div&gt;...
+// ...Style the &lt;div&gt;...
 
-              dom.document.body.append(tooltipElem);</pre>
+dom.document.body.append(tooltipElem);</pre>
 
   <p><strong>Important:</strong>
 Because Angular expects to have full control of the DOM,
@@ -290,8 +288,7 @@ so that’s the type that tooltipForRecipe() returns.</p>
           80);
     }
     return tooltip[recipe]; // recipe.tooltip
-  }
-</pre>
+}</pre>
 
   <p>The use of <a href="https://api.dartlang.org/dart_core/Expando.html">Expando</a>
 is an implementation detail.


### PR DESCRIPTION
In Chapters 2 to 4:
- Removing unnecessary blank lines at the end of some code excerpts.
- Removing leading whitespace so that all code samples are consistent
  with Chapter (which has no leading space for, e.g., HTML excerpts).
- Other minor code excerpt cleanup.
